### PR TITLE
raise minimum node to version 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "aframe": ""
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Required to fix CI

Node 4 [is no longer maintained](https://github.com/nodejs/Release), and, as of the next (imminent) release, (no longer supported by Ember](https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md)